### PR TITLE
Fixed windows-specific gradle properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.java.home=C:\\Program Files\\Java\\jdk1.8.0_181

--- a/gradlew
+++ b/gradlew
@@ -6,8 +6,6 @@
 ##
 ##############################################################################
 
-org.gradle.java.home=C:\\Program Files\\Java\\jdk1.8.0_144
-
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS=""
 

--- a/src/main/java/com/github/tgstation/fastdmm/FastDMM.java
+++ b/src/main/java/com/github/tgstation/fastdmm/FastDMM.java
@@ -302,18 +302,21 @@ public class FastDMM extends JFrame implements ActionListener, TreeSelectionList
 							Util.filterTree(currentRoot, f);
 							objTreeVis.setModel(null);
 							objTreeVis.setModel(objTree);
-							
+
 							for (int i = 0; i < objTreeVis.getRowCount(); i++) {
 								objTreeVis.expandRow(i);
 							}
 	
 						} else {
 							Util.setAllVisible(currentRoot);
+							objTreeVis.setModel(null);
+							objTreeVis.setModel(objTree);
+
 							for (int i = 1; i < objTreeVis.getRowCount(); i++) { //start at 1 so we dont collapse turf mob area obj
 								objTreeVis.collapseRow(i);
 							}
 						}
-						objTreeVis.repaint();
+						objTreeVis.validate();
 					}
 				}
 				


### PR DESCRIPTION
There was a line setting the java home for gradle to a windows-specific directory. This should be in the local gradle properties, not the project ones, to allow gradle to build the project on any OS.